### PR TITLE
Error when it runs in OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Currently, it is a simple bash script which measures the performance of a termin
 - the none unicode character
 - a mix of unicode and none characters
 
+> if you are running on osx, you'll need to install coreutils **brew install coreutils**
 
 Any feedback and help to extend the project is welcome.
 

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
 MAX_RETRIES=100000
-START=$(date +%s.%N)
-// 6*42 + 48
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  START=$(date +%s.%N)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  START=$(gdate +%s.%N)
+fi
+# 7*42 + 48
 for i in {1..100000}; do
   echo -e '\r';
   echo -e '\033[0K\033[1mBold\033[0m \033[7mInvert\033[0m \033[4mUnderline\033[0m';
@@ -17,32 +21,55 @@ for i in {1..100000}; do
   echo -e '\033[0K\033[30m\033[41m Red \033[42m Green \033[43m Yellow \033[44m Blue \033[45m Magenta \033[46m Cyan \033[0m';
   echo -e '\033[0K\033[30m\033[1m\033[4m\033[41m Red \033[42m Green \033[43m Yellow \033[44m Blue \033[45m Magenta \033[46m Cyan \033[0m';
 done
-END=$(date +%s.%N)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  END=$(date +%s.%N)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  END=$(gdate +%s.%N)
+fi
 echo "Coloured output test takes: " + $(echo "($END - $START)" | bc) + " seconds"
 COLOURED_OUPUT=$(echo "(300 * $MAX_RETRIES) / ($END - $START)" | bc)
 
-
-START=$(date +%s.%N)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  START=$(date +%s.%N)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  START=$(gdate +%s.%N)
+fi
 for i in {1..100000}; do
   echo -e '\r';
   echo -e '🎫💋📂💣💒💁💀💳📄📕📦📷🔈🔙🔪🔻🔻🕊🕊🕛🕬🕽🖎🖎🖎🖍🖞🗀🗑🗢🗳🗡🗤🗣🗺🗻🗼🗽🗾🗿🗮🗝🗌🖻🖪🖙🖈🕷🕦🕕🔳🔢🔑🔀📯📞📍💼💫💚💉👸👧👖🐴🐣🐒🐁🏰🏟🏎🎽🎬🎛🎊🍹🍨🍗';
 done
-END=$(date +%s.%N)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  END=$(date +%s.%N)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  END=$(gdate +%s.%N)
+fi
 echo "Unicode output test takes: " $(echo "($END - $START)" | bc) " seconds"
 UNICODE_OUPUT=$(echo "(139 * $MAX_RETRIES) / ($END - $START)" | bc)
 
 
-START=$(date +%s.%N)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  START=$(date +%s.%N)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  START=$(gdate +%s.%N)
+fi
 for i in {1..100000}; do
   echo -e '\r';
   echo -e 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ';
 done
-END=$(date +%s.%N)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  END=$(date +%s.%N)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  END=$(gdate +%s.%N)
+fi
 echo "Non-unicode output test takes: " $(echo "($END - $START)" | bc) " seconds"
 NONE_UNICODE_OUPUT=$(echo "(118 * $MAX_RETRIES) / ($END - $START)" | bc)
 
 test_output='';
-START=$(date +%s.%N)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  START=$(date +%s.%N)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  START=$(gdate +%s.%N)
+fi
 for x in {1..10}; do
   test_output="${test_output} a🎫"
   for i in {1..100000}; do
@@ -50,7 +77,11 @@ for x in {1..10}; do
     echo -e $test_output;
   done
 done
-END=$(date +%s.%N)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  END=$(date +%s.%N)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  END=$(gdate +%s.%N)
+fi
 echo "Mixed output test takes: " $(echo "($END - $START)" | bc) " seconds"
 MIXED_OUPUT=$(echo "(165 * $MAX_RETRIES) / ($END - $START)" | bc)
 
@@ -59,4 +90,3 @@ echo "${COLOURED_OUPUT} coloured characters per second"
 echo "${UNICODE_OUPUT} unicode characters per second"
 echo "${NONE_UNICODE_OUPUT} none-unicode characters per second"
 echo "${MIXED_OUPUT} Mixed characters per second"
-


### PR DESCRIPTION
the script doesn't work on os x because it has a different way to show date, one workaround is to install coreutils and replace date to use **g**date

```
brew install coreutils

```
(standard_in) 1: illegal character: N
(standard_in) 1: illegal character: N
Mixed output test takes:   seconds
(standard_in) 1: illegal character: N
(standard_in) 1: illegal character: N
 coloured characters per second
 unicode characters per second
 none-unicode characters per second
 Mixed characters per second